### PR TITLE
Improvements to signal streams API

### DIFF
--- a/examples/interface_state_stream.rs
+++ b/examples/interface_state_stream.rs
@@ -6,24 +6,61 @@ use supplicant::{Interface, Supplicant, SupplicantError};
 async fn main() -> Result<(), Box<dyn Error>> {
     let supplicant = Supplicant::connect().await?;
 
-    let wlan_interface = find_interface(&supplicant, "wlan0")
+    let iface_rm_stream = supplicant.receive_interface_removed().await;
+    tokio::pin!(iface_rm_stream);
+    let iface_add_stream = supplicant.receive_interface_added().await;
+    tokio::pin!(iface_add_stream);
+
+    let mut wlan_interface = find_interface(&supplicant, "wlan0")
         .await
         .ok_or("Failed to find wlan0")??;
 
-    let state_stream = wlan_interface.state_stream().await;
+    let state_stream = wlan_interface.receive_state_changed();
     tokio::pin!(state_stream);
-    while let Some(state_res) = state_stream.next().await {
-        println!("new state: {:?}", state_res);
-        let status_code = wlan_interface.association_status().await;
-        println!("  status code: {:?}", status_code);
-        if !matches!(status_code, Ok(supplicant::ieee80211::StatusCode::Success)) {
-            let disconnect_reason = wlan_interface.disconnect_reason().await;
-            println!("  disconnect reason: {:?}", disconnect_reason);
-            let auth_status = wlan_interface.authentication_status().await;
-            println!("  auth status: {:?}", auth_status);
+
+    loop {
+        tokio::select! {
+            state_res_opt = state_stream.next() => {
+                match state_res_opt {
+                    Some(state_res) => print_state_info(&wlan_interface, state_res).await,
+                    None => break,
+                }
+            }
+            rm_iface = iface_rm_stream.next() => {
+                println!("Interface removed: {:?}", rm_iface);
+            }
+            add_iface = iface_add_stream.next() => {
+                let iface = add_iface.unwrap()?;
+                let ifname = iface.ifname().await?;
+                println!("Interface added: {:?}", ifname);
+
+                if ifname == "wlan0" {
+                    wlan_interface = iface;
+                    let new_state_stream = wlan_interface.receive_state_changed().await;
+                    state_stream.set(new_state_stream);
+                }
+            }
         }
     }
+    println!("Exiting");
     Ok(())
+}
+
+async fn print_state_info<'a>(
+    wlan_interface: &'a Interface<'_>,
+    state_res: supplicant::Result<supplicant::InterfaceState>,
+) {
+    println!("new state: {:?}", state_res);
+    let status_code = wlan_interface.association_status().await;
+    println!("  status code: {:?}", status_code);
+    if !matches!(status_code, Ok(supplicant::ieee80211::StatusCode::Success))
+        || matches!(state_res, Ok(supplicant::InterfaceState::Disconnected))
+    {
+        let disconnect_reason = wlan_interface.disconnect_reason().await;
+        println!("  disconnect reason: {:?}", disconnect_reason);
+        let auth_status = wlan_interface.authentication_status().await;
+        println!("  auth status: {:?}", auth_status);
+    }
 }
 
 async fn find_interface<'a>(
@@ -35,13 +72,14 @@ async fn find_interface<'a>(
         let ifname = iface.ifname().await;
 
         match ifname {
-            Ok(name) if &name == iface_name.as_ref() => {
+            Ok(name) if name == iface_name.as_ref() => {
+                println!("found iface: {:?}", name);
                 iface_res = Some(Ok(iface));
                 break;
             }
             // Store the last err to return at the end
             Err(e) => {
-                iface_res = Some(Err(e.into()));
+                iface_res = Some(Err(e));
             }
             // Ignore other ifaces
             Ok(_) => {}

--- a/examples/scan_networks.rs
+++ b/examples/scan_networks.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .ok_or("Failed to find wlan0")??;
 
     let scan_done_fut = async {
-        let scan_done_stream = wlan_interface.scan_done_stream().await;
+        let scan_done_stream = wlan_interface.receive_scan_done().await;
         tokio::pin!(scan_done_stream);
         scan_done_stream.next().await.unwrap()
     };
@@ -38,7 +38,7 @@ async fn find_interface<'a>(
         let ifname = iface.ifname().await;
 
         match ifname {
-            Ok(name) if &name == iface_name.as_ref() => {
+            Ok(name) if name == iface_name.as_ref() => {
                 iface_res = Some(Ok(iface));
                 break;
             }

--- a/src/ieee80211/mod.rs
+++ b/src/ieee80211/mod.rs
@@ -1,6 +1,5 @@
-
 mod reason;
 pub use reason::{Reason, ReasonCode};
 
 mod status;
-pub use status::{StatusCode};
+pub use status::StatusCode;

--- a/src/ieee80211/reason.rs
+++ b/src/ieee80211/reason.rs
@@ -10,7 +10,7 @@ impl From<i32> for Reason {
         let locally_generated = value.is_negative();
         Self {
             code,
-            locally_generated
+            locally_generated,
         }
     }
 }
@@ -230,7 +230,7 @@ impl From<u16> for ReasonCode {
             WLAN_REASON_MAC_ADDRESS_ALREADY_EXISTS_IN_MBSS => MacAddressAlreadyExistsInMbss,
             WLAN_REASON_MESH_CHANNEL_SWITCH_REGULATORY_REQ => MeshChannelSwitchRegulatoryReq,
             WLAN_REASON_MESH_CHANNEL_SWITCH_UNSPECIFIED => MeshChannelSwitchUnspecified,
-            val @ _ => Unknown(val),
+            val => Unknown(val),
         }
     }
 }

--- a/src/ieee80211/status.rs
+++ b/src/ieee80211/status.rs
@@ -314,7 +314,7 @@ impl From<u16> for StatusCode {
             WLAN_STATUS_SAE_HASH_TO_ELEMENT => SaeHashToElement,
             WLAN_STATUS_SAE_PK => SaePk,
 
-            val @ _ => Unknown(val),
+            val => Unknown(val),
         }
     }
 }
@@ -429,4 +429,3 @@ impl From<StatusCode> for u16 {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,8 @@ pub enum InterfaceState {
     FourwayHandshake,
     GroupHandshake,
     Completed,
-    Unknown
+    Unknown,
+    InterfaceDisabled,
 }
 
 impl FromStr for InterfaceState {
@@ -337,7 +338,10 @@ impl FromStr for InterfaceState {
             "group_handshake" => GroupHandshake,
             "completed" => Completed,
             "unknown" => Unknown,
-            _ => Err(zbus::Error::Variant(zbus::zvariant::Error::Message(format!("Failed to parse State value '{}'", s))))?
+            "interface_disabled" => InterfaceDisabled,
+            _ => Err(zbus::Error::Variant(zbus::zvariant::Error::Message(
+                format!("Failed to parse State value '{}'", s),
+            )))?,
         };
 
         Ok(val)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,16 @@
 pub mod ieee80211;
 mod proxy;
 
-use std::str::FromStr;
+use futures_util::StreamExt;
 use proxy::{
     dbus_wpa::wpa_supplicant1Proxy, dbus_wpa_bss::BSSProxy, dbus_wpa_interface::InterfaceProxy,
 };
+use std::str::FromStr;
 use thiserror::Error;
 
+use crate::ieee80211::{Reason, StatusCode};
 use zbus::zvariant::OwnedObjectPath;
 use zbus::{CacheProperties, Connection, Error as ZbusError};
-use crate::ieee80211::{Reason, StatusCode};
 
 pub const SUPPLICANT_DBUS_NAME: &str = "fi.w1.wpa_supplicant1";
 
@@ -21,7 +22,7 @@ pub enum SupplicantError {
     #[error(transparent)]
     Dbus(DbusError),
     #[error(transparent)]
-    Io(#[from] std::io::Error)
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -35,10 +36,8 @@ impl From<ZbusError> for SupplicantError {
         match zbus_err {
             #[allow(deprecated)]
             ZbusError::Io(io_err) => io_err.into(),
-            ZbusError::InputOutput(io_err) => {
-                std::io::Error::new(io_err.kind(), io_err).into()
-            },
-            _ => SupplicantError::Dbus(DbusError { inner: zbus_err })
+            ZbusError::InputOutput(io_err) => std::io::Error::new(io_err.kind(), io_err).into(),
+            _ => SupplicantError::Dbus(DbusError { inner: zbus_err }),
         }
     }
 }
@@ -60,17 +59,43 @@ impl<'a> Supplicant<'a> {
     }
 
     #[tracing::instrument]
-    pub async fn interfaces(&'a self) -> Result<Vec<Interface<'a>>> {
+    pub async fn interfaces(&self) -> Result<Vec<Interface<'_>>> {
         let interfaces = self.proxy.interfaces().await?;
 
         futures_util::future::join_all(
-            interfaces
-                .into_iter()
-                .map(|object_path| Interface::new(self.conn.clone(), &self.proxy, object_path)),
+            interfaces.into_iter().map(|object_path| {
+                Interface::new(self.conn.clone(), self.proxy.clone(), object_path)
+            }),
         )
         .await
         .into_iter()
         .collect::<Result<_>>()
+    }
+
+    #[tracing::instrument]
+    pub async fn receive_interface_added(
+        &self,
+    ) -> impl futures_util::Stream<Item = Result<Interface<'_>>> + '_ {
+        let iface_added_stream = self.proxy.receive_interface_added().await.unwrap();
+        iface_added_stream.then(move |iface_added| {
+            let proxy = self.proxy.clone();
+            async move {
+                let object_path = iface_added.args()?.path;
+                Interface::new(self.conn.clone(), proxy, object_path.into()).await
+            }
+        })
+    }
+
+    #[tracing::instrument]
+    pub async fn receive_interface_removed(
+        &self,
+    ) -> impl futures_util::Stream<Item = Result<OwnedObjectPath>> + '_ {
+        let iface_removed_stream = self.proxy.receive_interface_removed().await.unwrap();
+        iface_removed_stream.then(move |iface_removed| async move {
+            let args = iface_removed.args()?;
+            let object_path = args.path;
+            Ok(object_path.into())
+        })
     }
 }
 
@@ -79,20 +104,20 @@ pub struct Interface<'a> {
     conn: Connection,
     _path: OwnedObjectPath,
     proxy: InterfaceProxy<'a>,
-    supplicant_proxy: &'a wpa_supplicant1Proxy<'a>,
+    supplicant_proxy: wpa_supplicant1Proxy<'a>,
 }
 
 impl<'a> Interface<'a> {
     #[tracing::instrument]
     pub(crate) async fn new(
         conn: Connection,
-        supplicant_proxy: &'a wpa_supplicant1Proxy<'_>,
+        supplicant_proxy: wpa_supplicant1Proxy<'a>,
         interface_path: OwnedObjectPath,
     ) -> Result<Interface<'a>> {
         let proxy = InterfaceProxy::builder(&conn)
             .destination(SUPPLICANT_DBUS_NAME)?
             .path(interface_path.clone())?
-            .cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::Lazily)
             .build()
             .await?;
 
@@ -105,7 +130,7 @@ impl<'a> Interface<'a> {
     }
 
     #[tracing::instrument]
-    pub async fn scan(&'a self) -> Result<()> {
+    pub async fn scan(&self) -> Result<()> {
         use std::collections::HashMap;
         let mut args: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
 
@@ -115,82 +140,68 @@ impl<'a> Interface<'a> {
     }
 
     #[tracing::instrument]
-    pub async fn scan_done_stream(&'a self) -> impl futures_util::Stream<Item = Result<bool>> + 'a {
-        use futures_util::stream::StreamExt;
+    pub async fn receive_scan_done(&self) -> impl futures_util::Stream<Item = Result<bool>> + 'a {
         // TODO: no unwrap
         let scan_done_stream = self.proxy.receive_scan_done().await.unwrap();
-        let s = scan_done_stream.filter_map(|signal| async move {
+        scan_done_stream.then(|signal| async move {
             tracing::trace!("signal: {:?}", &signal);
-            let args = match signal.args() {
-                Ok(args) => args,
-                Err(e) => return Some(Err(e.into())),
-            };
-            tracing::trace!("args: {:?}", &args);
-            Some(Ok(args.success))
-        });
-        s
+            Ok(signal.args()?.success)
+        })
     }
 
     #[tracing::instrument]
-    pub async fn list_networks(&'a self) -> Result<Vec<Bss<'a>>> {
+    pub async fn list_networks(&self) -> Result<Vec<Bss<'_>>> {
         let bsss = self.proxy.bsss().await?;
-        futures_util::future::join_all(
-            bsss.into_iter()
-                .map(|object_path| Bss::new(self.conn.clone(), self.supplicant_proxy, object_path)),
-        )
+        futures_util::future::join_all(bsss.into_iter().map(|object_path| {
+            Bss::new(
+                self.conn.clone(),
+                self.supplicant_proxy.clone(),
+                object_path,
+            )
+        }))
         .await
         .into_iter()
         .collect::<Result<_>>()
     }
 
     #[tracing::instrument]
-    pub async fn ifname(&'a self) -> Result<String> {
+    pub async fn ifname(&self) -> Result<String> {
         self.proxy.ifname().await.map_err(From::from)
     }
 
     #[tracing::instrument]
-    pub async fn state(&'a self) -> Result<InterfaceState> {
+    pub async fn state(&self) -> Result<InterfaceState> {
         self.proxy.state().await?.parse().map_err(From::from)
     }
 
     #[tracing::instrument]
-    pub async fn state_stream(&'a self) -> impl futures_util::Stream<Item = Result<InterfaceState>> + 'a {
-        use futures_util::stream::StreamExt;
-        // TODO: no unwrap
-        let prop_stream = self.proxy.receive_properties_changed().await.unwrap();
-        let s = prop_stream.filter_map(|signal| async move {
-            tracing::trace!("signal: {:?}", &signal);
-            let args = match signal.args() {
-                Ok(args) => args,
-                Err(e) => return Some(Err(e.into())),
-            };
-            tracing::trace!("args: {:?}", &args);
-
-            let props = args.properties();
-            for (name, value) in props.iter() {
-                tracing::trace!(name = ?name, new_value = ?value, "Interface property changed");
-            }
-
-            let new_state = props.get("State")?;
-            let val: &str = new_state.downcast_ref()?;
-
-            Some(val.parse().map_err(From::from))
-        });
-        s
+    pub async fn receive_state_changed(
+        &self,
+    ) -> impl futures_util::Stream<Item = Result<InterfaceState>> + 'a {
+        let proxy = self.proxy.clone();
+        proxy
+            .receive_state_changed()
+            .await
+            .then(|state_prop| async move {
+                state_prop.get().await.map_err(From::from).and_then(|val| {
+                    tracing::trace!("state: {:?}", &val);
+                    val.parse().map_err(From::from)
+                })
+            })
     }
 
     #[tracing::instrument]
-    pub async fn disconnect_reason(&'a self) -> Result<Reason> {
+    pub async fn disconnect_reason(&self) -> Result<Reason> {
         Ok(self.proxy.disconnect_reason().await?.into())
     }
 
     #[tracing::instrument]
-    pub async fn association_status(&'a self) -> Result<StatusCode> {
+    pub async fn association_status(&self) -> Result<StatusCode> {
         Ok((self.proxy.assoc_status_code().await? as u16).into())
     }
 
     #[tracing::instrument]
-    pub async fn authentication_status(&'a self) -> Result<StatusCode> {
+    pub async fn authentication_status(&self) -> Result<StatusCode> {
         Ok((self.proxy.auth_status_code().await? as u16).into())
     }
 }
@@ -200,20 +211,20 @@ pub struct Bss<'a> {
     _conn: Connection,
     _path: OwnedObjectPath,
     proxy: BSSProxy<'a>,
-    _supplicant_proxy: &'a wpa_supplicant1Proxy<'a>,
+    _supplicant_proxy: wpa_supplicant1Proxy<'a>,
 }
 
 impl<'a> Bss<'a> {
     #[tracing::instrument]
     pub(crate) async fn new(
         conn: Connection,
-        supplicant_proxy: &'a wpa_supplicant1Proxy<'_>,
+        supplicant_proxy: wpa_supplicant1Proxy<'a>,
         bss_path: OwnedObjectPath,
     ) -> Result<Bss<'a>> {
         let proxy = BSSProxy::builder(&conn)
             .destination(SUPPLICANT_DBUS_NAME)?
             .path(bss_path.clone())?
-            .cache_properties(CacheProperties::No)
+            .cache_properties(CacheProperties::Lazily)
             .build()
             .await?;
 
@@ -225,36 +236,39 @@ impl<'a> Bss<'a> {
         })
     }
 
-    pub async fn bssid(&'a self) -> Result<Vec<u8>> {
+    pub async fn bssid(&self) -> Result<Vec<u8>> {
         self.proxy.bssid().await.map_err(From::from)
     }
 
-    pub async fn frequency(&'a self) -> Result<u16> {
+    pub async fn frequency(&self) -> Result<u16> {
         self.proxy.frequency().await.map_err(From::from)
     }
 
-    pub async fn ssid(&'a self) -> Result<Vec<u8>> {
+    pub async fn ssid(&self) -> Result<Vec<u8>> {
         self.proxy.ssid().await.map_err(From::from)
     }
 
-    pub async fn signal(&'a self) -> Result<i16> {
+    pub async fn signal(&self) -> Result<i16> {
         self.proxy.signal().await.map_err(From::from)
     }
 
-    pub async fn wpa(&'a self) -> Result<Wpa> {
+    pub async fn wpa(&self) -> Result<Wpa> {
         let mut wpa_value = self.proxy.wpa().await?;
         let key_mgmt = wpa_value
             .remove("KeyMgmt")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
         let pairwise = wpa_value
             .remove("Pairwise")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
         let group = wpa_value
             .remove("Group")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
 
         Ok(Wpa {
             key_mgmt,
@@ -263,24 +277,28 @@ impl<'a> Bss<'a> {
         })
     }
 
-    pub async fn rsn(&'a self) -> Result<Rsn> {
+    pub async fn rsn(&self) -> Result<Rsn> {
         let mut wpa_value = self.proxy.rsn().await?;
         let key_mgmt = wpa_value
             .remove("KeyMgmt")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
         let pairwise = wpa_value
             .remove("Pairwise")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
         let group = wpa_value
             .remove("Group")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
         let mgmt_group = wpa_value
             .remove("MgmtGroup")
             .map(|v| v.try_into())
-            .transpose().map_err(ZbusError::from)?;
+            .transpose()
+            .map_err(ZbusError::from)?;
 
         Ok(Rsn {
             key_mgmt,


### PR DESCRIPTION
- Adopt zbus' `receive_*` terminology to avoid confusion for now.
- Rework `interface_state_stream` example to track `wlan0` through
  teardown and re-initialization, via `interface_removed` / `_added`
  supplicant signals.
- Clippy fixes
- Rustfmt

Also adds `InterfaceState::InterfaceDisabled` variant. The dbus documentation omits this, but it is present in the `wpa_states` enum from which the dbus property is derived.