### PR TITLE
feat: make enums out of ssid security params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ license = "MIT/Apache-2.0"
 [dependencies]
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"
 zbus = { version = "3", default-features = false, features = ["tokio"] }
+zvariant = { version = "3" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/examples/interface_state_stream.rs
+++ b/examples/interface_state_stream.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await
         .ok_or("Failed to find wlan0")??;
 
-    let state_stream = wlan_interface.receive_state_changed();
+    let state_stream = wlan_interface.receive_state_changed().await;
     tokio::pin!(state_stream);
 
     loop {


### PR DESCRIPTION
Utilizes `strum` and `zbus`/`zvariant` shenanigans to strongly-type the `WPA` and `RSN` security properties within [`BSS`](https://w1.fi/wpa_supplicant/devel/dbus.html#dbus_bss).

I tried a couple different avenues to try and get some of the deserialization for free (particularly deriving or impl'ing `From<OwnedValue>` all the way down), but some of the intermediate structures (e.g. `HashMap<String, OwnedValue>`) seemed to foil that. But this implementation works, exposes properly-typed variants, and the internal stuff can always be cleaned up later.

---

Example output from `scan_networks`:
```
SSID:  SomeSsid123
BSSID:  11:22:33:44:55:66
FREQ:   2462
SIGNAL: -64
WPA:    Wpa { key_mgmt: Some({}), pairwise: Some({}), group: None }
RSN:    Rsn { key_mgmt: Some({WpaPsk}), pairwise: Some({Ccmp}), group: Some(Ccmp), mgmt_group: Some(Aes128cmac) }

SSID:   AnotherSsid456
BSSID:  77:88:99:AA:BB:CC
FREQ:   2462
SIGNAL: -88
WPA:    Wpa { key_mgmt: Some({WpaPsk}), pairwise: Some({Tkip, Ccmp}), group: Some(Tkip) }
RSN:    Rsn { key_mgmt: Some({WpaPsk}), pairwise: Some({Ccmp, Tkip}), group: Some(Tkip), mgmt_group: Some(Aes128cmac) }
```