### PR TITLE
deps: set minimum zbus version to 3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1", features = ["derive"] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"
-zbus = { version = "3", default-features = false, features = ["tokio"] }
+zbus = { version = "3.7", default-features = false, features = ["tokio"] }
 zvariant = { version = "3" }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes an issue where earlier versions fail to compile on missing `Error::InputOutput`, as that was only first introduced in 3.7.0.

Ref: https://github.com/dbus2/zbus/releases/tag/zbus-3.7.0