### PR TITLE
deps: make serde optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 futures-util = "0.3"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"], optional = true }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"

--- a/src/ieee80211/reason.rs
+++ b/src/ieee80211/reason.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Reason {
     code: ReasonCode,
     locally_generated: bool,
@@ -99,6 +103,7 @@ const WLAN_REASON_MESH_CHANNEL_SWITCH_REGULATORY_REQ: u16 = 65;
 const WLAN_REASON_MESH_CHANNEL_SWITCH_UNSPECIFIED: u16 = 66;
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum ReasonCode {
     Unspecified,
     PrevAuthNotValid,

--- a/src/ieee80211/status.rs
+++ b/src/ieee80211/status.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /* Status codes (IEEE Std 802.11-2016, 9.4.1.9, Table 9-46) */
 const WLAN_STATUS_SUCCESS: u16 = 0;
 const WLAN_STATUS_UNSPECIFIED_FAILURE: u16 = 1;
@@ -102,6 +105,7 @@ const WLAN_STATUS_SAE_HASH_TO_ELEMENT: u16 = 126;
 const WLAN_STATUS_SAE_PK: u16 = 127;
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum StatusCode {
     Success,
     UnspecifiedFailure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use proxy::{
 };
 
 #[cfg(feature = "serde")]
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use std::collections::HashSet;
 use std::convert::Infallible;
@@ -398,10 +398,21 @@ macro_rules! impl_traits_for_fromstr {
                 $ty::from_str(s.as_str()).map_err(serde::de::Error::custom)
             }
         }
+
+        #[cfg(feature = "serde")]
+        impl Serialize for $ty {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
     };
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Wpa {
     pub key_mgmt: Option<HashSet<wpa::KeyMgmt>>,
     pub pairwise: Option<HashSet<wpa::Pairwise>>,
@@ -409,6 +420,7 @@ pub struct Wpa {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Rsn {
     pub key_mgmt: Option<HashSet<rsn::KeyMgmt>>,
     pub pairwise: Option<HashSet<rsn::Pairwise>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ use futures_util::StreamExt;
 use proxy::{
     dbus_wpa::wpa_supplicant1Proxy, dbus_wpa_bss::BSSProxy, dbus_wpa_interface::InterfaceProxy,
 };
+
+#[cfg(feature = "serde")]
 use serde::Deserialize;
+
 use std::collections::HashSet;
 use std::convert::Infallible;
 use strum::ParseError;
@@ -384,6 +387,7 @@ macro_rules! impl_traits_for_fromstr {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl<'de> Deserialize<'de> for $ty {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
             where
@@ -413,7 +417,9 @@ pub struct Rsn {
 }
 
 mod wpa {
+    #[cfg(feature = "serde")]
     use serde::Deserialize;
+
     use strum::EnumString;
     use zvariant::Type;
 
@@ -452,7 +458,9 @@ mod wpa {
     impl_traits_for_fromstr!(Group);
 }
 mod rsn {
+    #[cfg(feature = "serde")]
     use serde::Deserialize;
+
     use strum::EnumString;
     use zvariant::Type;
 


### PR DESCRIPTION
zbus unconditionally pulls this in as a dependency, but it would still be beneficial to gate explicit struct derives on a feature flag.

Also derive `Deserialize` / `Serialize` for various structs.