### PR TITLE
Add interface getter method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "supplicant"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 description = "Bindings for wpa_supplicant"
 repository = "https://github.com/jmagnuson/supplicant-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,13 @@ impl<'a> Supplicant<'a> {
     }
 
     #[tracing::instrument]
+    pub async fn get_interface(&self, ifname: &str) -> Result<Interface<'_>> {
+        let object_path = self.proxy.get_interface(ifname).await?;
+
+        Interface::new(self.conn.clone(), self.proxy.clone(), object_path).await
+    }
+
+    #[tracing::instrument]
     pub async fn receive_interface_added(
         &self,
     ) -> impl futures_util::Stream<Item = Result<Interface<'_>>> + '_ {


### PR DESCRIPTION
`Supplicant::interfaces` can't simply be used to look for newly-added interfaces (e.g. `wlan0`) since zbus [caches](https://dbus2.github.io/zbus/client.html#watching-for-changes) the property value by default. It's not clear if we should change this behavior, but utilizing a dedicated getter is the better solution for this anyway.